### PR TITLE
chore: add device count API, apispeclint errors fix and preprod

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,11 @@ SDK Methods to consume
 	- [Get Destination](#get-destination)
 	- [Update Destination](#update-destination)
 	- [Delete Destination](#delete-destination)
-- [Destination Devices](#destination-device)
-	- [List Destination device](#list-destination-devices)
-	- [Get Destination device report](#get-destination-device-report)
+- [Push Destination APIs](#push-destination-apis)
 	- [Create Destination tag subscription](#create-destination-tag-subscription)
 	- [List Destination tag subscription](#list-destination-tag-subscription)
 	- [List Destination device tag subscriptions](#list-destination-device-tag-subscriptions)
+  - [Get Device Count](#get-device-count)
 	- [Delete Destination device tag subscription](#delete-destination-device-tag-subscription)
 - [Subscriptions](#subscriptions)
 	- [Create Subscription](#create-subscription)
@@ -431,42 +430,7 @@ eventNotificationsService
   });
 ```
 
-## Destination Devices
-
-### List Destination device
-
-```js
-const params = {
-  instanceId: <instance-id>,
-  id: <destination-id>,
-};
-
-let res;
-try {
-  res = await eventNotificationsService.listDestinationDevices(params);
-  console.log(JSON.stringify(res.result, null, 2));
-} catch (err) {
-  console.warn(err);
-}
-```
-
-### Get Destination device report
-
-```js
-
-const params = {
-  instanceId: <instance-id>,
-  id: <destination-id>,
-};
-
-let res;
-try {
-  res = await eventNotificationsService.getDestinationDevicesReport(params);
-  console.log(JSON.stringify(res.result, null, 2));
-} catch (err) {
-  console.warn(err);
-}
-```
+## Push Destination APIs
 
 ### Create Destination tag subscription
 
@@ -520,6 +484,23 @@ try {
 } catch (err) {
   console.warn(err);
 }
+```
+
+### Get Device Count
+
+```js
+const params = {
+  instanceId: <instance-id>,
+  id: <destination-id>,
+};
+let res;
+try {
+  res = res = await eventNotificationsService.getDeviceCount(params);
+  console.log(JSON.stringify(res.result, null, 2));
+} catch (err) {
+  console.warn(err);
+}
+
 ```
 
 ### Delete Destination device tag subscription

--- a/event-notifications/v1.ts
+++ b/event-notifications/v1.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * IBM OpenAPI SDK Code Generator Version: 3.46.0-a4e29da0-20220224-210428
+ * IBM OpenAPI SDK Code Generator Version: 3.54.0-af6d2126-20220803-151219
  */
 
 import * as extend from 'extend';
@@ -100,29 +100,11 @@ class EventNotificationsV1 extends BaseService {
   /**
    * Send a notification.
    *
+   * Send Notifications body from the instance.
+   *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.instanceId - Unique identifier for IBM Cloud Event Notifications instance.
    * @param {NotificationCreate} [params.body] -
-   * @param {string} [params.ceIbmenseverity] - The Notification severity.
-   * @param {string} [params.ceIbmendefaultshort] - The Notification default short text.
-   * @param {string} [params.ceIbmendefaultlong] - The Notification default long text.
-   * @param {string} [params.ceIbmenfcmbody] - The FCM Notification body.
-   * @param {string} [params.ceIbmenapnsbody] - The APNS Notification body.
-   * @param {string} [params.ceIbmensafaribody] - The safari Notification body.
-   * @param {string} [params.ceIbmenpushto] - Push Notifications Targets.
-   * @param {string} [params.ceIbmenapnsheaders] - Push Notifications APNS Headers.
-   * @param {string} [params.ceIbmenchromebody] - Push Notifications Chrome body.
-   * @param {string} [params.ceIbmenfirefoxbody] - Push Notifications Firefox body.
-   * @param {string} [params.ceIbmenchromeheaders] - Push Notifications Chrome Headers.
-   * @param {string} [params.ceIbmenfirefoxheaders] - Push Notifications Firefox Headers.
-   * @param {string} [params.ceIbmensourceid] - Event Notifications Target source ID.
-   * @param {string} [params.ceId] - custom ID to track notifications from client side (Mandatory identifier for the
-   * binary mode).
-   * @param {string} [params.ceSource] - custom source odentifier from the client side.
-   * @param {string} [params.ceType] - Type identifier for source filters.
-   * @param {string} [params.ceSpecversion] - Version of the Cloud Event specification (Mandatory header to make the
-   * request Binary Mode).
-   * @param {string} [params.ceTime] - The time of the notification.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.NotificationResponse>>}
    */
@@ -131,29 +113,7 @@ class EventNotificationsV1 extends BaseService {
   ): Promise<EventNotificationsV1.Response<EventNotificationsV1.NotificationResponse>> {
     const _params = { ...params };
     const _requiredParams = ['instanceId'];
-    const _validParams = [
-      'instanceId',
-      'body',
-      'ceIbmenseverity',
-      'ceIbmendefaultshort',
-      'ceIbmendefaultlong',
-      'ceIbmenfcmbody',
-      'ceIbmenapnsbody',
-      'ceIbmensafaribody',
-      'ceIbmenpushto',
-      'ceIbmenapnsheaders',
-      'ceIbmenchromebody',
-      'ceIbmenfirefoxbody',
-      'ceIbmenchromeheaders',
-      'ceIbmenfirefoxheaders',
-      'ceIbmensourceid',
-      'ceId',
-      'ceSource',
-      'ceType',
-      'ceSpecversion',
-      'ceTime',
-      'headers',
-    ];
+    const _validParams = ['instanceId', 'body', 'headers'];
     const _validationErrors = validateParams(_params, _requiredParams, _validParams);
     if (_validationErrors) {
       return Promise.reject(_validationErrors);
@@ -184,24 +144,6 @@ class EventNotificationsV1 extends BaseService {
           {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
-            'ce-ibmenseverity': _params.ceIbmenseverity,
-            'ce-ibmendefaultshort': _params.ceIbmendefaultshort,
-            'ce-ibmendefaultlong': _params.ceIbmendefaultlong,
-            'ce-ibmenfcmbody': _params.ceIbmenfcmbody,
-            'ce-ibmenapnsbody': _params.ceIbmenapnsbody,
-            'ce-ibmensafaribody': _params.ceIbmensafaribody,
-            'ce-ibmenpushto': _params.ceIbmenpushto,
-            'ce-ibmenapnsheaders': _params.ceIbmenapnsheaders,
-            'ce-ibmenchromebody': _params.ceIbmenchromebody,
-            'ce-ibmenfirefoxbody': _params.ceIbmenfirefoxbody,
-            'ce-ibmenchromeheaders': _params.ceIbmenchromeheaders,
-            'ce-ibmenfirefoxheaders': _params.ceIbmenfirefoxheaders,
-            'ce-ibmensourceid': _params.ceIbmensourceid,
-            'ce-id': _params.ceId,
-            'ce-source': _params.ceSource,
-            'ce-type': _params.ceType,
-            'ce-specversion': _params.ceSpecversion,
-            'ce-time': _params.ceTime,
           },
           _params.headers
         ),
@@ -926,7 +868,7 @@ class EventNotificationsV1 extends BaseService {
         data: _params.icon16x16,
         contentType: _params.icon16x16ContentType,
       },
-      'icon_16x16@2x': {
+      'icon_16x16_2x': {
         data: _params.icon16x162x,
         contentType: _params.icon16x162xContentType,
       },
@@ -934,7 +876,7 @@ class EventNotificationsV1 extends BaseService {
         data: _params.icon32x32,
         contentType: _params.icon32x32ContentType,
       },
-      'icon_32x32@2x': {
+      'icon_32x32_2x': {
         data: _params.icon32x322x,
         contentType: _params.icon32x322xContentType,
       },
@@ -942,7 +884,7 @@ class EventNotificationsV1 extends BaseService {
         data: _params.icon128x128,
         contentType: _params.icon128x128ContentType,
       },
-      'icon_128x128@2x': {
+      'icon_128x128_2x': {
         data: _params.icon128x1282x,
         contentType: _params.icon128x1282xContentType,
       },
@@ -1169,7 +1111,7 @@ class EventNotificationsV1 extends BaseService {
         data: _params.icon16x16,
         contentType: _params.icon16x16ContentType,
       },
-      'icon_16x16@2x': {
+      'icon_16x16_2x': {
         data: _params.icon16x162x,
         contentType: _params.icon16x162xContentType,
       },
@@ -1177,7 +1119,7 @@ class EventNotificationsV1 extends BaseService {
         data: _params.icon32x32,
         contentType: _params.icon32x32ContentType,
       },
-      'icon_32x32@2x': {
+      'icon_32x32_2x': {
         data: _params.icon32x322x,
         contentType: _params.icon32x322xContentType,
       },
@@ -1185,7 +1127,7 @@ class EventNotificationsV1 extends BaseService {
         data: _params.icon128x128,
         contentType: _params.icon128x128ContentType,
       },
-      'icon_128x128@2x': {
+      'icon_128x128_2x': {
         data: _params.icon128x1282x,
         contentType: _params.icon128x1282xContentType,
       },
@@ -1272,136 +1214,7 @@ class EventNotificationsV1 extends BaseService {
     return this.createRequest(parameters);
   }
   /*************************
-   * destinationsPushDevices
-   ************************/
-
-  /**
-   * Get list of Destination devices.
-   *
-   * Get list of Destination devices.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.instanceId - Unique identifier for IBM Cloud Event Notifications instance.
-   * @param {string} params.id - Unique identifier for Destination.
-   * @param {number} [params.limit] - Page limit for paginated results.
-   * @param {number} [params.offset] - offset for paginated results.
-   * @param {string} [params.search] - Search string for filtering results.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.DestinationDevicesList>>}
-   */
-  public listDestinationDevices(
-    params: EventNotificationsV1.ListDestinationDevicesParams
-  ): Promise<EventNotificationsV1.Response<EventNotificationsV1.DestinationDevicesList>> {
-    const _params = { ...params };
-    const _requiredParams = ['instanceId', 'id'];
-    const _validParams = ['instanceId', 'id', 'limit', 'offset', 'search', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const query = {
-      'limit': _params.limit,
-      'offset': _params.offset,
-      'search': _params.search,
-    };
-
-    const path = {
-      'instance_id': _params.instanceId,
-      'id': _params.id,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      EventNotificationsV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'listDestinationDevices'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/instances/{instance_id}/destinations/{id}/devices',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Retrieves report of destination devices registered.
-   *
-   * Retrieves report of destination devices registered.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.instanceId - Unique identifier for IBM Cloud Event Notifications instance.
-   * @param {string} params.id - Unique identifier for Destination.
-   * @param {number} [params.days] - Number of days report has to be generated from
-   * * `Note :` Max value is 90
-   * * Min or default value is 1.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.DestinationDevicesReport>>}
-   */
-  public getDestinationDevicesReport(
-    params: EventNotificationsV1.GetDestinationDevicesReportParams
-  ): Promise<EventNotificationsV1.Response<EventNotificationsV1.DestinationDevicesReport>> {
-    const _params = { ...params };
-    const _requiredParams = ['instanceId', 'id'];
-    const _validParams = ['instanceId', 'id', 'days', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const query = {
-      'days': _params.days,
-    };
-
-    const path = {
-      'instance_id': _params.instanceId,
-      'id': _params.id,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      EventNotificationsV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'getDestinationDevicesReport'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/instances/{instance_id}/destinations/{id}/devices/report',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-  /*************************
-   * destinationTagsSubscriptions
+   * pushDestinationAPIs
    ************************/
 
   /**
@@ -1419,8 +1232,8 @@ class EventNotificationsV1 extends BaseService {
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.TagsSubscriptionList>>}
    */
-  public listTagsSubscriptionsDevice(
-    params: EventNotificationsV1.ListTagsSubscriptionsDeviceParams
+  public getTagsSubscriptionsDevice(
+    params: EventNotificationsV1.GetTagsSubscriptionsDeviceParams
   ): Promise<EventNotificationsV1.Response<EventNotificationsV1.TagsSubscriptionList>> {
     const _params = { ...params };
     const _requiredParams = ['instanceId', 'id', 'deviceId'];
@@ -1445,7 +1258,7 @@ class EventNotificationsV1 extends BaseService {
     const sdkHeaders = getSdkHeaders(
       EventNotificationsV1.DEFAULT_SERVICE_NAME,
       'v1',
-      'listTagsSubscriptionsDevice'
+      'getTagsSubscriptionsDevice'
     );
 
     const parameters = {
@@ -1461,6 +1274,125 @@ class EventNotificationsV1 extends BaseService {
           sdkHeaders,
           {
             'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Get Device count.
+   *
+   * Get Device count.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - Unique identifier for IBM Cloud Event Notifications instance.
+   * @param {string} params.id - Unique identifier for Destination.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.DeviceCount>>}
+   */
+  public getDeviceCount(
+    params: EventNotificationsV1.GetDeviceCountParams
+  ): Promise<EventNotificationsV1.Response<EventNotificationsV1.DeviceCount>> {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId', 'id'];
+    const _validParams = ['instanceId', 'id', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const path = {
+      'instance_id': _params.instanceId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      EventNotificationsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'getDeviceCount'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/instances/{instance_id}/destinations/{id}/devices/count',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+          },
+          _params.headers
+        ),
+      }),
+    };
+
+    return this.createRequest(parameters);
+  }
+
+  /**
+   * Create a new Tag subscription.
+   *
+   * Create a new Tag subscription.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.instanceId - Unique identifier for IBM Cloud Event Notifications instance.
+   * @param {string} params.id - Unique identifier for Destination.
+   * @param {string} params.deviceId - Unique identifier of the device.
+   * @param {string} params.tagName - The name of the tag its subscribed.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.DestinationTagsSubscriptionResponse>>}
+   */
+  public createTagsSubscription(
+    params: EventNotificationsV1.CreateTagsSubscriptionParams
+  ): Promise<
+    EventNotificationsV1.Response<EventNotificationsV1.DestinationTagsSubscriptionResponse>
+  > {
+    const _params = { ...params };
+    const _requiredParams = ['instanceId', 'id', 'deviceId', 'tagName'];
+    const _validParams = ['instanceId', 'id', 'deviceId', 'tagName', 'headers'];
+    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
+    if (_validationErrors) {
+      return Promise.reject(_validationErrors);
+    }
+
+    const body = {
+      'device_id': _params.deviceId,
+      'tag_name': _params.tagName,
+    };
+
+    const path = {
+      'instance_id': _params.instanceId,
+      'id': _params.id,
+    };
+
+    const sdkHeaders = getSdkHeaders(
+      EventNotificationsV1.DEFAULT_SERVICE_NAME,
+      'v1',
+      'createTagsSubscription'
+    );
+
+    const parameters = {
+      options: {
+        url: '/v1/instances/{instance_id}/destinations/{id}/tag_subscriptions',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this.baseOptions, {
+        headers: extend(
+          true,
+          sdkHeaders,
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
           },
           _params.headers
         ),
@@ -1541,71 +1473,6 @@ class EventNotificationsV1 extends BaseService {
           sdkHeaders,
           {
             'Accept': 'application/json',
-          },
-          _params.headers
-        ),
-      }),
-    };
-
-    return this.createRequest(parameters);
-  }
-
-  /**
-   * Create a new Tag subscription.
-   *
-   * Create a new Tag subscription.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.instanceId - Unique identifier for IBM Cloud Event Notifications instance.
-   * @param {string} params.id - Unique identifier for Destination.
-   * @param {string} params.deviceId - Unique identifier of the device.
-   * @param {string} params.tagName - The name of the tag its subscribed.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @returns {Promise<EventNotificationsV1.Response<EventNotificationsV1.DestinationTagsSubscriptionResponse>>}
-   */
-  public createTagsSubscription(
-    params: EventNotificationsV1.CreateTagsSubscriptionParams
-  ): Promise<
-    EventNotificationsV1.Response<EventNotificationsV1.DestinationTagsSubscriptionResponse>
-  > {
-    const _params = { ...params };
-    const _requiredParams = ['instanceId', 'id', 'deviceId', 'tagName'];
-    const _validParams = ['instanceId', 'id', 'deviceId', 'tagName', 'headers'];
-    const _validationErrors = validateParams(_params, _requiredParams, _validParams);
-    if (_validationErrors) {
-      return Promise.reject(_validationErrors);
-    }
-
-    const body = {
-      'device_id': _params.deviceId,
-      'tag_name': _params.tagName,
-    };
-
-    const path = {
-      'instance_id': _params.instanceId,
-      'id': _params.id,
-    };
-
-    const sdkHeaders = getSdkHeaders(
-      EventNotificationsV1.DEFAULT_SERVICE_NAME,
-      'v1',
-      'createTagsSubscription'
-    );
-
-    const parameters = {
-      options: {
-        url: '/v1/instances/{instance_id}/destinations/{id}/tag_subscriptions',
-        method: 'POST',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this.baseOptions, {
-        headers: extend(
-          true,
-          sdkHeaders,
-          {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
           },
           _params.headers
         ),
@@ -2010,42 +1877,6 @@ namespace EventNotificationsV1 {
     /** Unique identifier for IBM Cloud Event Notifications instance. */
     instanceId: string;
     body?: NotificationCreate;
-    /** The Notification severity. */
-    ceIbmenseverity?: string;
-    /** The Notification default short text. */
-    ceIbmendefaultshort?: string;
-    /** The Notification default long text. */
-    ceIbmendefaultlong?: string;
-    /** The FCM Notification body. */
-    ceIbmenfcmbody?: string;
-    /** The APNS Notification body. */
-    ceIbmenapnsbody?: string;
-    /** The safari Notification body. */
-    ceIbmensafaribody?: string;
-    /** Push Notifications Targets. */
-    ceIbmenpushto?: string;
-    /** Push Notifications APNS Headers. */
-    ceIbmenapnsheaders?: string;
-    /** Push Notifications Chrome body. */
-    ceIbmenchromebody?: string;
-    /** Push Notifications Firefox body. */
-    ceIbmenfirefoxbody?: string;
-    /** Push Notifications Chrome Headers. */
-    ceIbmenchromeheaders?: string;
-    /** Push Notifications Firefox Headers. */
-    ceIbmenfirefoxheaders?: string;
-    /** Event Notifications Target source ID. */
-    ceIbmensourceid?: string;
-    /** custom ID to track notifications from client side (Mandatory identifier for the binary mode). */
-    ceId?: string;
-    /** custom source odentifier from the client side. */
-    ceSource?: string;
-    /** Type identifier for source filters. */
-    ceType?: string;
-    /** Version of the Cloud Event specification (Mandatory header to make the request Binary Mode). */
-    ceSpecversion?: string;
-    /** The time of the notification. */
-    ceTime?: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -2310,34 +2141,8 @@ namespace EventNotificationsV1 {
     headers?: OutgoingHttpHeaders;
   }
 
-  /** Parameters for the `listDestinationDevices` operation. */
-  export interface ListDestinationDevicesParams {
-    /** Unique identifier for IBM Cloud Event Notifications instance. */
-    instanceId: string;
-    /** Unique identifier for Destination. */
-    id: string;
-    /** Page limit for paginated results. */
-    limit?: number;
-    /** offset for paginated results. */
-    offset?: number;
-    /** Search string for filtering results. */
-    search?: string;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `getDestinationDevicesReport` operation. */
-  export interface GetDestinationDevicesReportParams {
-    /** Unique identifier for IBM Cloud Event Notifications instance. */
-    instanceId: string;
-    /** Unique identifier for Destination. */
-    id: string;
-    /** Number of days report has to be generated from * `Note :` Max value is 90 * Min or default value is 1. */
-    days?: number;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `listTagsSubscriptionsDevice` operation. */
-  export interface ListTagsSubscriptionsDeviceParams {
+  /** Parameters for the `getTagsSubscriptionsDevice` operation. */
+  export interface GetTagsSubscriptionsDeviceParams {
     /** Unique identifier for IBM Cloud Event Notifications instance. */
     instanceId: string;
     /** Unique identifier for Destination. */
@@ -2350,6 +2155,28 @@ namespace EventNotificationsV1 {
     limit?: number;
     /** offset for paginated results. */
     offset?: number;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `getDeviceCount` operation. */
+  export interface GetDeviceCountParams {
+    /** Unique identifier for IBM Cloud Event Notifications instance. */
+    instanceId: string;
+    /** Unique identifier for Destination. */
+    id: string;
+    headers?: OutgoingHttpHeaders;
+  }
+
+  /** Parameters for the `createTagsSubscription` operation. */
+  export interface CreateTagsSubscriptionParams {
+    /** Unique identifier for IBM Cloud Event Notifications instance. */
+    instanceId: string;
+    /** Unique identifier for Destination. */
+    id: string;
+    /** Unique identifier of the device. */
+    deviceId: string;
+    /** The name of the tag its subscribed. */
+    tagName: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -2371,19 +2198,6 @@ namespace EventNotificationsV1 {
     offset?: number;
     /** Search string for filtering results. */
     search?: string;
-    headers?: OutgoingHttpHeaders;
-  }
-
-  /** Parameters for the `createTagsSubscription` operation. */
-  export interface CreateTagsSubscriptionParams {
-    /** Unique identifier for IBM Cloud Event Notifications instance. */
-    instanceId: string;
-    /** Unique identifier for Destination. */
-    id: string;
-    /** Unique identifier of the device. */
-    deviceId: string;
-    /** The name of the tag its subscribed. */
-    tagName: string;
     headers?: OutgoingHttpHeaders;
   }
 
@@ -2501,50 +2315,6 @@ namespace EventNotificationsV1 {
   /** DestinationConfigParams. */
   export interface DestinationConfigParams {}
 
-  /** Payload describing a destination devices list request. */
-  export interface DestinationDevicesList {
-    /** Total number of destination devices. */
-    total_count: number;
-    /** Current offset. */
-    offset: number;
-    /** limit to show destination devices. */
-    limit: number;
-    /** List of devices. */
-    devices: DestinationDevicesListItem[];
-  }
-
-  /** device object. */
-  export interface DestinationDevicesListItem {
-    /** device ID. */
-    id: string;
-    /** user ID. */
-    user_id?: string;
-    /** Destination platform. */
-    platform: string;
-    /** Destination device token. */
-    token: string;
-    /** Updated at. */
-    updated_at: string;
-  }
-
-  /** Payload describing a destination devices report. */
-  export interface DestinationDevicesReport {
-    /** Android Devices Registered. */
-    android: number;
-    /** ios Devices Registered. */
-    ios: number;
-    /** chrome web Devices Registered. */
-    chrome: number;
-    /** firefox web Devices Registered. */
-    firefox: number;
-    /** safari web Devices Registered. */
-    safari: number;
-    /** chromeAppExt Devices Registered. */
-    chromeAppExt: number;
-    /** Total Devices Registered. */
-    all: number;
-  }
-
   /** Payload describing a destination list request. */
   export interface DestinationList {
     /** Total number of destinations. */
@@ -2565,7 +2335,7 @@ namespace EventNotificationsV1 {
     name: string;
     /** Destination description. */
     description: string;
-    /** Destination typeEmail/SMS/Webhook/Slack/Safari/MSTeams. */
+    /** Destination type. */
     type: string;
     /** Subscription count. */
     subscription_count: number;
@@ -2605,6 +2375,36 @@ namespace EventNotificationsV1 {
     created_at: string;
   }
 
+  /** Payload describing Device Count. */
+  export interface DeviceCount {
+    /** Total number of devices. */
+    total_count: number;
+  }
+
+  /** EmailAttributesResponseInvitedItem. */
+  export interface EmailAttributesResponseInvitedItem {
+    /** email address. */
+    email?: string;
+    /** time of addition. */
+    time?: string;
+  }
+
+  /** EmailAttributesResponseToItem. */
+  export interface EmailAttributesResponseToItem {
+    /** email address. */
+    email?: string;
+    /** time of addition. */
+    time?: string;
+  }
+
+  /** EmailAttributesResponseUnsubscribedItem. */
+  export interface EmailAttributesResponseUnsubscribedItem {
+    /** email address. */
+    email?: string;
+    /** time of addition. */
+    time?: string;
+  }
+
   /** The email ids. */
   export interface EmailUpdateAttributesTo {
     /** The email ids. */
@@ -2621,51 +2421,50 @@ namespace EventNotificationsV1 {
 
   /** Payload describing a notification create request. */
   export interface NotificationCreate {
-    /** The Notifications data for webhook. */
-    data?: JsonObject;
-    /** The Notifications id. */
+    /** The version of the notification specification. */
+    specversion: string;
+    /** The time notification was created. */
+    time?: string;
+    /** The unique identifier of the notification. */
+    id?: string;
+    /** The source of notifications. */
+    source?: string;
+    /** The notifications type. */
+    type?: string;
+    /** The severity of the notification. */
     ibmenseverity?: string;
-    /** The Notifications FCM body. */
-    ibmenfcmbody?: string;
-    /** The Notifications APNS body. */
-    ibmenapnsbody?: string;
-    /** The Notifications safari body. */
-    ibmensafaribody?: string;
-    /** This field should not be empty. The allowed fields are fcm_devices, apns_devices, chrome_devices,
-     *  firefox_devices, platforms, tags and user_ids. If platforms or tags or user_ids are being used then do not use
-     *  fcm_devices / apns_devices / chrome_devices / firefox_devices with it.
+    /** The source id of the notification. */
+    ibmensourceid: string;
+    /** Default short text for the message. */
+    ibmendefaultshort: string;
+    /** Default long text for the message. */
+    ibmendefaultlong: string;
+    /** The subject of the notification. */
+    subject?: string;
+    /** The payload for webhook notification. */
+    data?: JsonObject;
+    /** The notification content type. */
+    datacontenttype?: string;
+    /** If platforms or tags or user_ids is used then do not use fcm_devices / apns_devices / chrome_devices /
+     *  firefox_devices / safari_devices with it. Value should be stringified json.
      */
     ibmenpushto?: string;
-    /** Headers for an APNs notification. */
+    /** Payload describing a notification FCM body. Value should be stringified json. */
+    ibmenfcmbody?: string;
+    /** Payload describing a notification APNs body. Value should be stringified json. */
+    ibmenapnsbody?: string;
+    /** Headers for iOS notification. Value should be stringified json. */
     ibmenapnsheaders?: string;
-    /** Default short text for the message. */
-    ibmendefaultshort?: string;
-    /** Default long text for the message. */
-    ibmendefaultlong?: string;
-    /** The Notifications Chrome body. */
+    /** Notification payload for Chrome. Value should be stringified json. */
     ibmenchromebody?: string;
-    /** The Notifications Firefox body. */
-    ibmenfirefoxbody?: string;
-    /** Headers for a Chrome notification. */
+    /** Headers for a Chrome notification. Value should be stringified json. */
     ibmenchromeheaders?: string;
-    /** Headers for an FireFox notification. */
+    /** Notification payload for Firefox. Value should be stringified json. */
+    ibmenfirefoxbody?: string;
+    /** Headers for a Firefox notification. Value should be stringified json. */
     ibmenfirefoxheaders?: string;
-    /** The Event Notifications source id. */
-    ibmensourceid?: string;
-    /** The Notifications content type. */
-    datacontenttype?: string;
-    /** The Notifications subject. */
-    subject?: string;
-    /** The Notifications id. */
-    id?: string;
-    /** The source of Notifications. */
-    source?: string;
-    /** The Notifications type. */
-    type?: string;
-    /** The Notifications specversion. */
-    specversion?: string;
-    /** The Notifications time. */
-    time?: string;
+    /** Payload describing a notification Safari body. Value should be stringified json. */
+    ibmensafaribody?: string;
     /** NotificationCreate accepts additional properties. */
     [propName: string]: any;
   }
@@ -2949,6 +2748,8 @@ namespace EventNotificationsV1 {
     website_url: string;
     /** Chrome VAPID public key. */
     public_key?: string;
+    /** If pre prod enabled. */
+    pre_prod?: boolean;
   }
 
   /** Payload describing a FCM destination configuration. */
@@ -2957,6 +2758,8 @@ namespace EventNotificationsV1 {
     server_key: string;
     /** FCM sender_id. */
     sender_id: string;
+    /** If pre prod enabled. */
+    pre_prod?: boolean;
   }
 
   /** Payload describing a Firefox destination configuration. */
@@ -2965,6 +2768,8 @@ namespace EventNotificationsV1 {
     website_url: string;
     /** Chrome VAPID public key. */
     public_key?: string;
+    /** If pre prod enabled. */
+    pre_prod?: boolean;
   }
 
   /** Payload describing a IOS destination configuration. */
@@ -2981,6 +2786,8 @@ namespace EventNotificationsV1 {
     team_id?: string;
     /** Bundle ID for token (Required when cert_type is p8). */
     bundle_id?: string;
+    /** If pre prod enabled. */
+    pre_prod?: boolean;
   }
 
   /** Payload describing a MS Teams destination configuration. */
@@ -2992,7 +2799,7 @@ namespace EventNotificationsV1 {
   /** Payload describing a safari destination configuration. */
   export interface DestinationConfigParamsSafariDestinationConfig extends DestinationConfigParams {
     /** Authentication type p12. */
-    cert_type?: string;
+    cert_type: string;
     /** Password for certificate (Required when cert_type is p12). */
     password: string;
     /** Websire url. */
@@ -3003,6 +2810,8 @@ namespace EventNotificationsV1 {
     url_format_string: string;
     /** Websire url. */
     website_push_id: string;
+    /** If pre prod enabled. */
+    pre_prod?: boolean;
   }
 
   /** Payload describing a slack destination configuration. */
@@ -3024,7 +2833,22 @@ namespace EventNotificationsV1 {
   }
 
   /** The attributes reponse for an email destination. */
-  export interface SubscriptionAttributesEmailAttributesResponse extends SubscriptionAttributes {}
+  export interface SubscriptionAttributesEmailAttributesResponse extends SubscriptionAttributes {
+    /** The email id string. */
+    to: EmailAttributesResponseToItem[];
+    /** The unsubscribe list. */
+    unsubscribed?: EmailAttributesResponseUnsubscribedItem[];
+    /** The invited list. */
+    invited?: EmailAttributesResponseInvitedItem[];
+    /** Whether to add the notification payload to the email. */
+    add_notification_payload: boolean;
+    /** The email address to reply to. */
+    reply_to_mail: string;
+    /** The email name to reply to. */
+    reply_to_name: string;
+    /** The email name of From. */
+    from_name: string;
+  }
 
   /** SMS attributes object. */
   export interface SubscriptionAttributesSMSAttributesResponse extends SubscriptionAttributes {}

--- a/examples/event-notifications.v1.test.js
+++ b/examples/event-notifications.v1.test.js
@@ -567,64 +567,6 @@ describe('EventNotificationsV1', () => {
     // end-update_destination
   });
 
-  test('listDestinationDevices request example', async () => {
-    consoleLogMock.mockImplementation((output) => {
-      originalLog(output);
-    });
-    consoleWarnMock.mockImplementation((output) => {
-      // if an error occurs, display the message and then fail the test
-      originalWarn(output);
-      expect(true).toBeFalsy();
-    });
-
-    originalLog('listDestinationDevices() result:');
-    // begin-list_destination_devices
-
-    const params = {
-      instanceId,
-      id: destinationId,
-    };
-
-    let res;
-    try {
-      res = await eventNotificationsService.listDestinationDevices(params);
-      console.log(JSON.stringify(res.result, null, 2));
-    } catch (err) {
-      console.warn(err);
-    }
-
-    // end-list_destination_devices
-  });
-
-  test('getDestinationDevicesReport request example', async () => {
-    consoleLogMock.mockImplementation((output) => {
-      originalLog(output);
-    });
-    consoleWarnMock.mockImplementation((output) => {
-      // if an error occurs, display the message and then fail the test
-      originalWarn(output);
-      expect(true).toBeFalsy();
-    });
-
-    originalLog('getDestinationDevicesReport() result:');
-    // begin-get_destination_devices_report
-
-    const params = {
-      instanceId,
-      id: destinationId,
-    };
-
-    let res;
-    try {
-      res = await eventNotificationsService.getDestinationDevicesReport(params);
-      console.log(JSON.stringify(res.result, null, 2));
-    } catch (err) {
-      console.warn(err);
-    }
-
-    // end-get_destination_devices_report
-  });
-
   test('createSubscription request example', async () => {
     consoleLogMock.mockImplementation((output) => {
       originalLog(output);
@@ -800,25 +742,32 @@ describe('EventNotificationsV1', () => {
       },
     };
 
-    const params = {
+    const notificationCreateModel = {
       instanceId,
-      ceIbmenseverity: notificationSeverity,
-      ceId: notificationID,
-      ceSource: notificationsSouce,
-      ceIbmensourceid: sourceId,
-      ceType: typeValue,
-      ceTime: date,
-      ceIbmenpushto: JSON.stringify(notificationFcmDevicesModel),
-      ceIbmenfcmbody: JSON.stringify(notificationFcmBodyModel),
-      ceIbmenapnsbody: JSON.stringify(notificationApnsBodyModel),
-      ceIbmensafaribody: JSON.stringify(notificationSafariBodymodel),
-      ceIbmenapnsheaders: JSON.stringify(apnsHeaders),
-      ceSpecversion: '1.0',
+      ibmenseverity: notificationSeverity,
+      id: notificationID,
+      source: notificationsSouce,
+      ibmensourceid: sourceId,
+      type: typeValue,
+      time: date,
+      ibmenpushto: JSON.stringify(notificationFcmDevicesModel),
+      ibmenfcmbody: JSON.stringify(notificationFcmBodyModel),
+      ibmenapnsbody: JSON.stringify(notificationApnsBodyModel),
+      ibmensafaribody: JSON.stringify(notificationSafariBodymodel),
+      ibmendefaultshort: 'testString',
+      ibmendefaultlong: 'testString',
+      specversion: '1.0',
+    };
+
+    const body = notificationCreateModel;
+    const sendNotificationsParams = {
+      instanceId,
+      body,
     };
 
     let res;
     try {
-      res = await eventNotificationsService.sendNotifications(params);
+      res = await eventNotificationsService.sendNotifications(sendNotificationsParams);
     } catch (err) {
       console.warn(err);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^12.0.8",
-        "eslint-config-airbnb": "^19.0.4",
+        "eslint-config-airbnb": ">=16.0.0",
         "extend": "^3.0.2",
         "ibm-cloud-sdk-core": "^2.17.9"
       },
@@ -39,7 +39,7 @@
         "typescript": "^4.5.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11605,9 +11605,10 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "19.0.2",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
+      "integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
@@ -11705,9 +11706,10 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.3",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -20496,7 +20498,9 @@
       }
     },
     "semantic-release": {
-      "version": "19.0.2",
+      "version": "19.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
+      "integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -20564,7 +20568,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.3",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true
     },
     "shebang-command": {

--- a/test/integration/event-notifications.v1.test.js
+++ b/test/integration/event-notifications.v1.test.js
@@ -675,41 +675,17 @@ describe('EventNotificationsV1_integration', () => {
     // 500
     //
   });
-  test('listDestinationDevices()', async () => {
+
+  test('getDeviceCount()', async () => {
     const params = {
       instanceId,
       id: destinationId3,
-      limit: 1,
-      offset: 0,
-      search: '',
     };
 
-    const res = await eventNotificationsService.listDestinationDevices(params);
+    const res = await eventNotificationsService.getDeviceCount(params);
     expect(res).toBeDefined();
     expect(res.status).toBe(200);
-    expect(res.result).toBeDefined();
-
-    //
-    // The following status codes aren't covered by tests.
-    // Please provide integration tests for these too.
-    //
-    // 401
-    // 404
-    // 500
-    //
-  });
-  test('getDestinationDevicesReport()', async () => {
-    const params = {
-      instanceId,
-      id: destinationId3,
-      days: 1,
-    };
-
-    const res = await eventNotificationsService.getDestinationDevicesReport(params);
-    expect(res).toBeDefined();
-    expect(res.status).toBe(200);
-    expect(res.result).toBeDefined();
-
+    expect(res.total_count).not.toBeNull();
     //
     // The following status codes aren't covered by tests.
     // Please provide integration tests for these too.
@@ -979,22 +955,30 @@ describe('EventNotificationsV1_integration', () => {
     const typeValue = 'com.acme.offer:new';
     const notificationsSouce = '1234-1234-sdfs-234:test';
 
-    const params = {
+    const notificationCreateModel = {
       instanceId,
-      ceIbmenseverity: notificationSeverity,
-      ceId: notificationID,
-      ceSource: notificationsSouce,
-      ceIbmensourceid: sourceId,
-      ceType: typeValue,
-      ceTime: '2019-01-01T12:00:00.000Z',
-      ceIbmenpushto: JSON.stringify(notificationFcmDevicesModel),
-      ceIbmenfcmbody: JSON.stringify(notificationFcmBodyModel),
-      ceIbmenapnsbody: JSON.stringify(notificationApnsBodyModel),
-      ceIbmensafaribody: JSON.stringify(notificationSafariBodymodel),
-      ceSpecversion: '1.0',
+      ibmenseverity: notificationSeverity,
+      id: notificationID,
+      source: notificationsSouce,
+      ibmensourceid: sourceId,
+      type: typeValue,
+      time: '2019-01-01T12:00:00.000Z',
+      ibmenpushto: JSON.stringify(notificationFcmDevicesModel),
+      ibmenfcmbody: JSON.stringify(notificationFcmBodyModel),
+      ibmenapnsbody: JSON.stringify(notificationApnsBodyModel),
+      ibmensafaribody: JSON.stringify(notificationSafariBodymodel),
+      ibmendefaultshort: 'Alert on offer',
+      ibmendefaultlong: 'Offer is going to expire soon',
+      specversion: '1.0',
     };
 
-    const res = await eventNotificationsService.sendNotifications(params);
+    let body = notificationCreateModel;
+    const sendNotificationsParams = {
+      instanceId,
+      body,
+    };
+
+    const res = await eventNotificationsService.sendNotifications(sendNotificationsParams);
 
     expect(res).toBeDefined();
     expect(res.status).toBe(202);
@@ -1020,24 +1004,31 @@ describe('EventNotificationsV1_integration', () => {
 
     const newParams = {
       instanceId,
-      ceIbmenseverity: notificationSeverity,
-      ceId: notificationID,
-      ceSource: notificationsSouce,
-      ceIbmensourceid: sourceId,
-      ceType: typeValue,
-      ceTime: '2019-01-01T12:00:00.000Z',
-      ceIbmenpushto: JSON.stringify(notificationFcmDevicesModel),
-      ceIbmenfcmbody: JSON.stringify(fcmOptions),
-      ceIbmenapnsbody: JSON.stringify(apnsOptions),
-      ceIbmenapnsheaders: JSON.stringify(apnsHeaders),
-      ceIbmensafaribody: JSON.stringify(notificationSafariBodymodel),
-      ceSpecversion: '1.0',
+      ibmenseverity: notificationSeverity,
+      id: notificationID,
+      source: notificationsSouce,
+      ibmensourceid: sourceId,
+      type: typeValue,
+      time: '2019-01-01T12:00:00.000Z',
+      ibmenpushto: JSON.stringify(notificationFcmDevicesModel),
+      ibmenfcmbody: JSON.stringify(fcmOptions),
+      ibmenapnsbody: JSON.stringify(apnsOptions),
+      ibmensafaribody: JSON.stringify(notificationSafariBodymodel),
+      ibmendefaultshort: 'testString',
+      ibmendefaultlong: 'testString',
+      specversion: '1.0',
     };
 
-    const rewRes = await eventNotificationsService.sendNotifications(newParams);
-    expect(rewRes).toBeDefined();
-    expect(rewRes.status).toBe(202);
-    expect(rewRes.result).toBeDefined();
+    body = newParams;
+    const sendNotificationsParamsnew = {
+      instanceId,
+      body,
+    };
+
+    const newres = await eventNotificationsService.sendNotifications(sendNotificationsParamsnew);
+    expect(newres).toBeDefined();
+    expect(newres.status).toBe(202);
+    expect(newres.result).toBeDefined();
 
     //
     // The following status codes aren't covered by tests.
@@ -1049,7 +1040,6 @@ describe('EventNotificationsV1_integration', () => {
     // 500
     //
   });
-
   test('sendBulkNotifications()', async () => {
     // Request models needed by this operation.
 
@@ -1269,7 +1259,6 @@ describe('EventNotificationsV1_integration', () => {
     expect(res).toBeDefined();
     expect(res.status).toBe(204);
     expect(res.result).toBeDefined();
-
     //
     // The following status codes aren't covered by tests.
     // Please provide integration tests for these too.

--- a/test/unit/event-notifications.v1.test.js
+++ b/test/unit/event-notifications.v1.test.js
@@ -21,8 +21,7 @@ const { NoAuthAuthenticator, unitTestUtils } = core;
 
 const EventNotificationsV1 = require('../../dist/event-notifications/v1');
 
-const { getOptions, checkUrlAndMethod, checkMediaHeaders, expectToBePromise, checkUserHeader } =
-  unitTestUtils;
+const { getOptions, checkUrlAndMethod, checkMediaHeaders, expectToBePromise } = unitTestUtils;
 
 const eventNotificationsServiceOptions = {
   authenticator: new NoAuthAuthenticator(),
@@ -31,20 +30,30 @@ const eventNotificationsServiceOptions = {
 
 const eventNotificationsService = new EventNotificationsV1(eventNotificationsServiceOptions);
 
-// dont actually create a request
-const createRequestMock = jest.spyOn(eventNotificationsService, 'createRequest');
-createRequestMock.mockImplementation(() => Promise.resolve());
+let createRequestMock = null;
+function mock_createRequest() {
+  if (!createRequestMock) {
+    createRequestMock = jest.spyOn(eventNotificationsService, 'createRequest');
+    createRequestMock.mockImplementation(() => Promise.resolve());
+  }
+}
 
 // dont actually construct an authenticator
 const getAuthenticatorMock = jest.spyOn(core, 'getAuthenticatorFromEnvironment');
 getAuthenticatorMock.mockImplementation(() => new NoAuthAuthenticator());
 
-afterEach(() => {
-  createRequestMock.mockClear();
-  getAuthenticatorMock.mockClear();
-});
-
 describe('EventNotificationsV1', () => {
+  beforeEach(() => {
+    mock_createRequest();
+  });
+
+  afterEach(() => {
+    if (createRequestMock) {
+      createRequestMock.mockClear();
+    }
+    getAuthenticatorMock.mockClear();
+  });
+
   describe('the newInstance method', () => {
     test('should use defaults when options not provided', () => {
       const testInstance = EventNotificationsV1.newInstance();
@@ -72,6 +81,7 @@ describe('EventNotificationsV1', () => {
       expect(testInstance).toBeInstanceOf(EventNotificationsV1);
     });
   });
+
   describe('the constructor', () => {
     test('use user-given service url', () => {
       const options = {
@@ -94,34 +104,34 @@ describe('EventNotificationsV1', () => {
       expect(testInstance.baseOptions.serviceUrl).toBe(EventNotificationsV1.DEFAULT_SERVICE_URL);
     });
   });
+
   describe('sendNotifications', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
       // NotificationCreate
       const notificationCreateModel = {
-        data: { 'key1': 'testString' },
-        ibmenseverity: 'testString',
-        ibmenfcmbody: 'testString',
-        ibmenapnsbody: 'testString',
-        ibmensafaribody: 'testString',
-        ibmenpushto:
-          '{"fcm_devices":["9c75975a-37d0-3898-905d-3b5ee0d7c172","C9CACDF5-6EBF-49E1-AD60-E25BA23E954C"],"apns_devices":["3423-37d0-3898-905d-42342","432423-6EBF-49E1-AD60-4234"],"user_ids":["user-1","user-2"],"tags":["tag-1","tag-2"],"platforms":["push_android","push_ios","push_chrome","push_firefox"]}',
-        ibmenapnsheaders: 'testString',
-        ibmendefaultshort: 'testString',
-        ibmendefaultlong: 'testString',
-        ibmenchromebody: 'testString',
-        ibmenfirefoxbody: 'testString',
-        ibmenchromeheaders: 'testString',
-        ibmenfirefoxheaders: 'testString',
-        ibmensourceid: 'testString',
-        datacontenttype: 'application/json',
-        subject: 'testString',
+        specversion: '1.0',
+        time: '2019-01-01T12:00:00.000Z',
         id: 'testString',
         source: 'testString',
         type: 'testString',
-        specversion: '1.0',
-        time: 'testString',
+        ibmenseverity: 'testString',
+        ibmensourceid: 'testString',
+        ibmendefaultshort: 'testString',
+        ibmendefaultlong: 'testString',
+        subject: 'testString',
+        data: { 'key1': 'testString' },
+        datacontenttype: 'application/json',
+        ibmenpushto: '{"platforms":["push_android"]}',
+        ibmenfcmbody: 'testString',
+        ibmenapnsbody: 'testString',
+        ibmenapnsheaders: 'testString',
+        ibmenchromebody: 'testString',
+        ibmenchromeheaders: '{"TTL":3600,"Topic":"test","Urgency":"high"}',
+        ibmenfirefoxbody: 'testString',
+        ibmenfirefoxheaders: '{"TTL":3600,"Topic":"test","Urgency":"high"}',
+        ibmensafaribody: 'testString',
         foo: 'testString',
       };
 
@@ -129,46 +139,9 @@ describe('EventNotificationsV1', () => {
         // Construct the params object for operation sendNotifications
         const instanceId = 'testString';
         const body = notificationCreateModel;
-        const ceIbmenseverity = 'testString';
-        const ceIbmendefaultshort = 'testString';
-        const ceIbmendefaultlong = 'testString';
-        const ceIbmenfcmbody = 'testString';
-        const ceIbmenapnsbody = 'testString';
-        const ceIbmensafaribody = 'testString';
-        const ceIbmenpushto =
-          '{"fcm_devices":["9c75975a-37d0-3898-905d-3b5ee0d7c172","C9CACDF5-6EBF-49E1-AD60-E25BA23E954C"],"apns_devices":["3423-37d0-3898-905d-42342","432423-6EBF-49E1-AD60-4234"],"user_ids":["user-1","user-2"],"tags":["tag-1","tag-2"],"platforms":["push_android","push_ios","push_chrome","push_firefox"]}';
-        const ceIbmenapnsheaders = 'testString';
-        const ceIbmenchromebody = 'testString';
-        const ceIbmenfirefoxbody = 'testString';
-        const ceIbmenchromeheaders = 'testString';
-        const ceIbmenfirefoxheaders = 'testString';
-        const ceIbmensourceid = 'testString';
-        const ceId = 'testString';
-        const ceSource = 'testString';
-        const ceType = 'testString';
-        const ceSpecversion = '1.0';
-        const ceTime = 'testString';
         const sendNotificationsParams = {
           instanceId,
           body,
-          ceIbmenseverity,
-          ceIbmendefaultshort,
-          ceIbmendefaultlong,
-          ceIbmenfcmbody,
-          ceIbmenapnsbody,
-          ceIbmensafaribody,
-          ceIbmenpushto,
-          ceIbmenapnsheaders,
-          ceIbmenchromebody,
-          ceIbmenfirefoxbody,
-          ceIbmenchromeheaders,
-          ceIbmenfirefoxheaders,
-          ceIbmensourceid,
-          ceId,
-          ceSource,
-          ceType,
-          ceSpecversion,
-          ceTime,
         };
 
         const sendNotificationsResult =
@@ -186,24 +159,6 @@ describe('EventNotificationsV1', () => {
         const expectedAccept = 'application/json';
         const expectedContentType = 'application/json';
         checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        checkUserHeader(createRequestMock, 'ce-ibmenseverity', ceIbmenseverity);
-        checkUserHeader(createRequestMock, 'ce-ibmendefaultshort', ceIbmendefaultshort);
-        checkUserHeader(createRequestMock, 'ce-ibmendefaultlong', ceIbmendefaultlong);
-        checkUserHeader(createRequestMock, 'ce-ibmenfcmbody', ceIbmenfcmbody);
-        checkUserHeader(createRequestMock, 'ce-ibmenapnsbody', ceIbmenapnsbody);
-        checkUserHeader(createRequestMock, 'ce-ibmensafaribody', ceIbmensafaribody);
-        checkUserHeader(createRequestMock, 'ce-ibmenpushto', ceIbmenpushto);
-        checkUserHeader(createRequestMock, 'ce-ibmenapnsheaders', ceIbmenapnsheaders);
-        checkUserHeader(createRequestMock, 'ce-ibmenchromebody', ceIbmenchromebody);
-        checkUserHeader(createRequestMock, 'ce-ibmenfirefoxbody', ceIbmenfirefoxbody);
-        checkUserHeader(createRequestMock, 'ce-ibmenchromeheaders', ceIbmenchromeheaders);
-        checkUserHeader(createRequestMock, 'ce-ibmenfirefoxheaders', ceIbmenfirefoxheaders);
-        checkUserHeader(createRequestMock, 'ce-ibmensourceid', ceIbmensourceid);
-        checkUserHeader(createRequestMock, 'ce-id', ceId);
-        checkUserHeader(createRequestMock, 'ce-source', ceSource);
-        checkUserHeader(createRequestMock, 'ce-type', ceType);
-        checkUserHeader(createRequestMock, 'ce-specversion', ceSpecversion);
-        checkUserHeader(createRequestMock, 'ce-time', ceTime);
         expect(mockRequestOptions.body).toEqual(body);
         expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
       }
@@ -265,34 +220,34 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('sendBulkNotifications', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
 
       // NotificationCreate
       const notificationCreateModel = {
-        data: { 'key1': 'testString' },
-        ibmenseverity: 'testString',
-        ibmenfcmbody: 'testString',
-        ibmenapnsbody: 'testString',
-        ibmensafaribody: 'testString',
-        ibmenpushto:
-          '{"fcm_devices":["9c75975a-37d0-3898-905d-3b5ee0d7c172","C9CACDF5-6EBF-49E1-AD60-E25BA23E954C"],"apns_devices":["3423-37d0-3898-905d-42342","432423-6EBF-49E1-AD60-4234"],"user_ids":["user-1","user-2"],"tags":["tag-1","tag-2"],"platforms":["push_android","push_ios","push_chrome","push_firefox"]}',
-        ibmenapnsheaders: 'testString',
-        ibmendefaultshort: 'testString',
-        ibmendefaultlong: 'testString',
-        ibmenchromebody: 'testString',
-        ibmenfirefoxbody: 'testString',
-        ibmenchromeheaders: 'testString',
-        ibmenfirefoxheaders: 'testString',
-        ibmensourceid: 'testString',
-        datacontenttype: 'application/json',
-        subject: 'testString',
+        specversion: '1.0',
+        time: '2019-01-01T12:00:00.000Z',
         id: 'testString',
         source: 'testString',
         type: 'testString',
-        specversion: '1.0',
-        time: 'testString',
+        ibmenseverity: 'testString',
+        ibmensourceid: 'testString',
+        ibmendefaultshort: 'testString',
+        ibmendefaultlong: 'testString',
+        subject: 'testString',
+        data: { 'key1': 'testString' },
+        datacontenttype: 'application/json',
+        ibmenpushto: '{"platforms":["push_android"]}',
+        ibmenfcmbody: 'testString',
+        ibmenapnsbody: 'testString',
+        ibmenapnsheaders: 'testString',
+        ibmenchromebody: 'testString',
+        ibmenchromeheaders: '{"TTL":3600,"Topic":"test","Urgency":"high"}',
+        ibmenfirefoxbody: 'testString',
+        ibmenfirefoxheaders: '{"TTL":3600,"Topic":"test","Urgency":"high"}',
+        ibmensafaribody: 'testString',
         foo: 'testString',
       };
 
@@ -386,6 +341,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('createSources', () => {
     describe('positive tests', () => {
       function __createSourcesTest() {
@@ -482,6 +438,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('listSources', () => {
     describe('positive tests', () => {
       function __listSourcesTest() {
@@ -574,6 +531,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('getSource', () => {
     describe('positive tests', () => {
       function __getSourceTest() {
@@ -662,6 +620,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('deleteSource', () => {
     describe('positive tests', () => {
       function __deleteSourceTest() {
@@ -750,6 +709,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('updateSource', () => {
     describe('positive tests', () => {
       function __updateSourceTest() {
@@ -847,6 +807,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('createTopic', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -956,6 +917,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('listTopics', () => {
     describe('positive tests', () => {
       function __listTopicsTest() {
@@ -1048,6 +1010,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('getTopic', () => {
     describe('positive tests', () => {
       function __getTopicTest() {
@@ -1139,6 +1102,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('replaceTopic', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -1251,6 +1215,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('deleteTopic', () => {
     describe('positive tests', () => {
       function __deleteTopicTest() {
@@ -1339,6 +1304,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('createDestination', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -1422,22 +1388,22 @@ describe('EventNotificationsV1', () => {
         expect(mockRequestOptions.formData.certificate.contentType).toEqual(certificateContentType);
         expect(mockRequestOptions.formData.icon_16x16.data).toEqual(icon16x16);
         expect(mockRequestOptions.formData.icon_16x16.contentType).toEqual(icon16x16ContentType);
-        expect(mockRequestOptions.formData['icon_16x16@2x'].data).toEqual(icon16x162x);
-        expect(mockRequestOptions.formData['icon_16x16@2x'].contentType).toEqual(
+        expect(mockRequestOptions.formData.icon_16x16_2x.data).toEqual(icon16x162x);
+        expect(mockRequestOptions.formData.icon_16x16_2x.contentType).toEqual(
           icon16x162xContentType
         );
         expect(mockRequestOptions.formData.icon_32x32.data).toEqual(icon32x32);
         expect(mockRequestOptions.formData.icon_32x32.contentType).toEqual(icon32x32ContentType);
-        expect(mockRequestOptions.formData['icon_32x32@2x'].data).toEqual(icon32x322x);
-        expect(mockRequestOptions.formData['icon_32x32@2x'].contentType).toEqual(
+        expect(mockRequestOptions.formData.icon_32x32_2x.data).toEqual(icon32x322x);
+        expect(mockRequestOptions.formData.icon_32x32_2x.contentType).toEqual(
           icon32x322xContentType
         );
         expect(mockRequestOptions.formData.icon_128x128.data).toEqual(icon128x128);
         expect(mockRequestOptions.formData.icon_128x128.contentType).toEqual(
           icon128x128ContentType
         );
-        expect(mockRequestOptions.formData['icon_128x128@2x'].data).toEqual(icon128x1282x);
-        expect(mockRequestOptions.formData['icon_128x128@2x'].contentType).toEqual(
+        expect(mockRequestOptions.formData.icon_128x128_2x.data).toEqual(icon128x1282x);
+        expect(mockRequestOptions.formData.icon_128x128_2x.contentType).toEqual(
           icon128x1282xContentType
         );
         expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
@@ -1504,6 +1470,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('listDestinations', () => {
     describe('positive tests', () => {
       function __listDestinationsTest() {
@@ -1597,6 +1564,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('getDestination', () => {
     describe('positive tests', () => {
       function __getDestinationTest() {
@@ -1689,6 +1657,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('updateDestination', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -1775,22 +1744,22 @@ describe('EventNotificationsV1', () => {
         expect(mockRequestOptions.formData.certificate.contentType).toEqual(certificateContentType);
         expect(mockRequestOptions.formData.icon_16x16.data).toEqual(icon16x16);
         expect(mockRequestOptions.formData.icon_16x16.contentType).toEqual(icon16x16ContentType);
-        expect(mockRequestOptions.formData['icon_16x16@2x'].data).toEqual(icon16x162x);
-        expect(mockRequestOptions.formData['icon_16x16@2x'].contentType).toEqual(
+        expect(mockRequestOptions.formData.icon_16x16_2x.data).toEqual(icon16x162x);
+        expect(mockRequestOptions.formData.icon_16x16_2x.contentType).toEqual(
           icon16x162xContentType
         );
         expect(mockRequestOptions.formData.icon_32x32.data).toEqual(icon32x32);
         expect(mockRequestOptions.formData.icon_32x32.contentType).toEqual(icon32x32ContentType);
-        expect(mockRequestOptions.formData['icon_32x32@2x'].data).toEqual(icon32x322x);
-        expect(mockRequestOptions.formData['icon_32x32@2x'].contentType).toEqual(
+        expect(mockRequestOptions.formData.icon_32x32_2x.data).toEqual(icon32x322x);
+        expect(mockRequestOptions.formData.icon_32x32_2x.contentType).toEqual(
           icon32x322xContentType
         );
         expect(mockRequestOptions.formData.icon_128x128.data).toEqual(icon128x128);
         expect(mockRequestOptions.formData.icon_128x128.contentType).toEqual(
           icon128x128ContentType
         );
-        expect(mockRequestOptions.formData['icon_128x128@2x'].data).toEqual(icon128x1282x);
-        expect(mockRequestOptions.formData['icon_128x128@2x'].contentType).toEqual(
+        expect(mockRequestOptions.formData.icon_128x128_2x.data).toEqual(icon128x1282x);
+        expect(mockRequestOptions.formData.icon_128x128_2x.contentType).toEqual(
           icon128x1282xContentType
         );
         expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
@@ -1856,6 +1825,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('deleteDestination', () => {
     describe('positive tests', () => {
       function __deleteDestinationTest() {
@@ -1949,216 +1919,18 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
-  describe('listDestinationDevices', () => {
+
+  describe('getTagsSubscriptionsDevice', () => {
     describe('positive tests', () => {
-      function __listDestinationDevicesTest() {
-        // Construct the params object for operation listDestinationDevices
-        const instanceId = 'testString';
-        const id = 'testString';
-        const limit = 1;
-        const offset = 0;
-        const search = 'testString';
-        const listDestinationDevicesParams = {
-          instanceId,
-          id,
-          limit,
-          offset,
-          search,
-        };
-
-        const listDestinationDevicesResult = eventNotificationsService.listDestinationDevices(
-          listDestinationDevicesParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(listDestinationDevicesResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/instances/{instance_id}/destinations/{id}/devices',
-          'GET'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.qs.limit).toEqual(limit);
-        expect(mockRequestOptions.qs.offset).toEqual(offset);
-        expect(mockRequestOptions.qs.search).toEqual(search);
-        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
-        expect(mockRequestOptions.path.id).toEqual(id);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __listDestinationDevicesTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        eventNotificationsService.enableRetries();
-        __listDestinationDevicesTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        eventNotificationsService.disableRetries();
-        __listDestinationDevicesTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const instanceId = 'testString';
-        const id = 'testString';
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const listDestinationDevicesParams = {
-          instanceId,
-          id,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        eventNotificationsService.listDestinationDevices(listDestinationDevicesParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async () => {
-        let err;
-        try {
-          await eventNotificationsService.listDestinationDevices({});
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-
-      test('should reject promise when required params are not given', async () => {
-        let err;
-        try {
-          await eventNotificationsService.listDestinationDevices();
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-    });
-  });
-  describe('getDestinationDevicesReport', () => {
-    describe('positive tests', () => {
-      function __getDestinationDevicesReportTest() {
-        // Construct the params object for operation getDestinationDevicesReport
-        const instanceId = 'testString';
-        const id = 'testString';
-        const days = 1;
-        const getDestinationDevicesReportParams = {
-          instanceId,
-          id,
-          days,
-        };
-
-        const getDestinationDevicesReportResult =
-          eventNotificationsService.getDestinationDevicesReport(getDestinationDevicesReportParams);
-
-        // all methods should return a Promise
-        expectToBePromise(getDestinationDevicesReportResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/instances/{instance_id}/destinations/{id}/devices/report',
-          'GET'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = undefined;
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.qs.days).toEqual(days);
-        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
-        expect(mockRequestOptions.path.id).toEqual(id);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __getDestinationDevicesReportTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        eventNotificationsService.enableRetries();
-        __getDestinationDevicesReportTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        eventNotificationsService.disableRetries();
-        __getDestinationDevicesReportTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const instanceId = 'testString';
-        const id = 'testString';
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const getDestinationDevicesReportParams = {
-          instanceId,
-          id,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        eventNotificationsService.getDestinationDevicesReport(getDestinationDevicesReportParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async () => {
-        let err;
-        try {
-          await eventNotificationsService.getDestinationDevicesReport({});
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-
-      test('should reject promise when required params are not given', async () => {
-        let err;
-        try {
-          await eventNotificationsService.getDestinationDevicesReport();
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-    });
-  });
-  describe('listTagsSubscriptionsDevice', () => {
-    describe('positive tests', () => {
-      function __listTagsSubscriptionsDeviceTest() {
-        // Construct the params object for operation listTagsSubscriptionsDevice
+      function __getTagsSubscriptionsDeviceTest() {
+        // Construct the params object for operation getTagsSubscriptionsDevice
         const instanceId = 'testString';
         const id = 'testString';
         const deviceId = 'testString';
         const tagName = 'testString';
         const limit = 1;
         const offset = 0;
-        const listTagsSubscriptionsDeviceParams = {
+        const getTagsSubscriptionsDeviceParams = {
           instanceId,
           id,
           deviceId,
@@ -2167,11 +1939,11 @@ describe('EventNotificationsV1', () => {
           offset,
         };
 
-        const listTagsSubscriptionsDeviceResult =
-          eventNotificationsService.listTagsSubscriptionsDevice(listTagsSubscriptionsDeviceParams);
+        const getTagsSubscriptionsDeviceResult =
+          eventNotificationsService.getTagsSubscriptionsDevice(getTagsSubscriptionsDeviceParams);
 
         // all methods should return a Promise
-        expectToBePromise(listTagsSubscriptionsDeviceResult);
+        expectToBePromise(getTagsSubscriptionsDeviceResult);
 
         // assert that create request was called
         expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2196,17 +1968,17 @@ describe('EventNotificationsV1', () => {
 
       test('should pass the right params to createRequest with enable and disable retries', () => {
         // baseline test
-        __listTagsSubscriptionsDeviceTest();
+        __getTagsSubscriptionsDeviceTest();
 
         // enable retries and test again
         createRequestMock.mockClear();
         eventNotificationsService.enableRetries();
-        __listTagsSubscriptionsDeviceTest();
+        __getTagsSubscriptionsDeviceTest();
 
         // disable retries and test again
         createRequestMock.mockClear();
         eventNotificationsService.disableRetries();
-        __listTagsSubscriptionsDeviceTest();
+        __getTagsSubscriptionsDeviceTest();
       });
 
       test('should prioritize user-given headers', () => {
@@ -2216,7 +1988,7 @@ describe('EventNotificationsV1', () => {
         const deviceId = 'testString';
         const userAccept = 'fake/accept';
         const userContentType = 'fake/contentType';
-        const listTagsSubscriptionsDeviceParams = {
+        const getTagsSubscriptionsDeviceParams = {
           instanceId,
           id,
           deviceId,
@@ -2226,7 +1998,7 @@ describe('EventNotificationsV1', () => {
           },
         };
 
-        eventNotificationsService.listTagsSubscriptionsDevice(listTagsSubscriptionsDeviceParams);
+        eventNotificationsService.getTagsSubscriptionsDevice(getTagsSubscriptionsDeviceParams);
         checkMediaHeaders(createRequestMock, userAccept, userContentType);
       });
     });
@@ -2235,7 +2007,7 @@ describe('EventNotificationsV1', () => {
       test('should enforce required parameters', async () => {
         let err;
         try {
-          await eventNotificationsService.listTagsSubscriptionsDevice({});
+          await eventNotificationsService.getTagsSubscriptionsDevice({});
         } catch (e) {
           err = e;
         }
@@ -2246,7 +2018,7 @@ describe('EventNotificationsV1', () => {
       test('should reject promise when required params are not given', async () => {
         let err;
         try {
-          await eventNotificationsService.listTagsSubscriptionsDevice();
+          await eventNotificationsService.getTagsSubscriptionsDevice();
         } catch (e) {
           err = e;
         }
@@ -2255,6 +2027,205 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
+  describe('getDeviceCount', () => {
+    describe('positive tests', () => {
+      function __getDeviceCountTest() {
+        // Construct the params object for operation getDeviceCount
+        const instanceId = 'testString';
+        const id = 'testString';
+        const getDeviceCountParams = {
+          instanceId,
+          id,
+        };
+
+        const getDeviceCountResult = eventNotificationsService.getDeviceCount(getDeviceCountParams);
+
+        // all methods should return a Promise
+        expectToBePromise(getDeviceCountResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/v1/instances/{instance_id}/destinations/{id}/devices/count',
+          'GET'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = undefined;
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __getDeviceCountTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        eventNotificationsService.enableRetries();
+        __getDeviceCountTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        eventNotificationsService.disableRetries();
+        __getDeviceCountTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const id = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const getDeviceCountParams = {
+          instanceId,
+          id,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        eventNotificationsService.getDeviceCount(getDeviceCountParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await eventNotificationsService.getDeviceCount({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await eventNotificationsService.getDeviceCount();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
+  describe('createTagsSubscription', () => {
+    describe('positive tests', () => {
+      function __createTagsSubscriptionTest() {
+        // Construct the params object for operation createTagsSubscription
+        const instanceId = 'testString';
+        const id = 'testString';
+        const deviceId = 'testString';
+        const tagName = 'testString';
+        const createTagsSubscriptionParams = {
+          instanceId,
+          id,
+          deviceId,
+          tagName,
+        };
+
+        const createTagsSubscriptionResult = eventNotificationsService.createTagsSubscription(
+          createTagsSubscriptionParams
+        );
+
+        // all methods should return a Promise
+        expectToBePromise(createTagsSubscriptionResult);
+
+        // assert that create request was called
+        expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+        const mockRequestOptions = getOptions(createRequestMock);
+
+        checkUrlAndMethod(
+          mockRequestOptions,
+          '/v1/instances/{instance_id}/destinations/{id}/tag_subscriptions',
+          'POST'
+        );
+        const expectedAccept = 'application/json';
+        const expectedContentType = 'application/json';
+        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+        expect(mockRequestOptions.body.device_id).toEqual(deviceId);
+        expect(mockRequestOptions.body.tag_name).toEqual(tagName);
+        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
+        expect(mockRequestOptions.path.id).toEqual(id);
+      }
+
+      test('should pass the right params to createRequest with enable and disable retries', () => {
+        // baseline test
+        __createTagsSubscriptionTest();
+
+        // enable retries and test again
+        createRequestMock.mockClear();
+        eventNotificationsService.enableRetries();
+        __createTagsSubscriptionTest();
+
+        // disable retries and test again
+        createRequestMock.mockClear();
+        eventNotificationsService.disableRetries();
+        __createTagsSubscriptionTest();
+      });
+
+      test('should prioritize user-given headers', () => {
+        // parameters
+        const instanceId = 'testString';
+        const id = 'testString';
+        const deviceId = 'testString';
+        const tagName = 'testString';
+        const userAccept = 'fake/accept';
+        const userContentType = 'fake/contentType';
+        const createTagsSubscriptionParams = {
+          instanceId,
+          id,
+          deviceId,
+          tagName,
+          headers: {
+            Accept: userAccept,
+            'Content-Type': userContentType,
+          },
+        };
+
+        eventNotificationsService.createTagsSubscription(createTagsSubscriptionParams);
+        checkMediaHeaders(createRequestMock, userAccept, userContentType);
+      });
+    });
+
+    describe('negative tests', () => {
+      test('should enforce required parameters', async () => {
+        let err;
+        try {
+          await eventNotificationsService.createTagsSubscription({});
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+
+      test('should reject promise when required params are not given', async () => {
+        let err;
+        try {
+          await eventNotificationsService.createTagsSubscription();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err.message).toMatch(/Missing required parameters/);
+      });
+    });
+  });
+
   describe('listTagsSubscription', () => {
     describe('positive tests', () => {
       function __listTagsSubscriptionTest() {
@@ -2367,110 +2338,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
-  describe('createTagsSubscription', () => {
-    describe('positive tests', () => {
-      function __createTagsSubscriptionTest() {
-        // Construct the params object for operation createTagsSubscription
-        const instanceId = 'testString';
-        const id = 'testString';
-        const deviceId = 'testString';
-        const tagName = 'testString';
-        const createTagsSubscriptionParams = {
-          instanceId,
-          id,
-          deviceId,
-          tagName,
-        };
 
-        const createTagsSubscriptionResult = eventNotificationsService.createTagsSubscription(
-          createTagsSubscriptionParams
-        );
-
-        // all methods should return a Promise
-        expectToBePromise(createTagsSubscriptionResult);
-
-        // assert that create request was called
-        expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-        const mockRequestOptions = getOptions(createRequestMock);
-
-        checkUrlAndMethod(
-          mockRequestOptions,
-          '/v1/instances/{instance_id}/destinations/{id}/tag_subscriptions',
-          'POST'
-        );
-        const expectedAccept = 'application/json';
-        const expectedContentType = 'application/json';
-        checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-        expect(mockRequestOptions.body.device_id).toEqual(deviceId);
-        expect(mockRequestOptions.body.tag_name).toEqual(tagName);
-        expect(mockRequestOptions.path.instance_id).toEqual(instanceId);
-        expect(mockRequestOptions.path.id).toEqual(id);
-      }
-
-      test('should pass the right params to createRequest with enable and disable retries', () => {
-        // baseline test
-        __createTagsSubscriptionTest();
-
-        // enable retries and test again
-        createRequestMock.mockClear();
-        eventNotificationsService.enableRetries();
-        __createTagsSubscriptionTest();
-
-        // disable retries and test again
-        createRequestMock.mockClear();
-        eventNotificationsService.disableRetries();
-        __createTagsSubscriptionTest();
-      });
-
-      test('should prioritize user-given headers', () => {
-        // parameters
-        const instanceId = 'testString';
-        const id = 'testString';
-        const deviceId = 'testString';
-        const tagName = 'testString';
-        const userAccept = 'fake/accept';
-        const userContentType = 'fake/contentType';
-        const createTagsSubscriptionParams = {
-          instanceId,
-          id,
-          deviceId,
-          tagName,
-          headers: {
-            Accept: userAccept,
-            'Content-Type': userContentType,
-          },
-        };
-
-        eventNotificationsService.createTagsSubscription(createTagsSubscriptionParams);
-        checkMediaHeaders(createRequestMock, userAccept, userContentType);
-      });
-    });
-
-    describe('negative tests', () => {
-      test('should enforce required parameters', async () => {
-        let err;
-        try {
-          await eventNotificationsService.createTagsSubscription({});
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-
-      test('should reject promise when required params are not given', async () => {
-        let err;
-        try {
-          await eventNotificationsService.createTagsSubscription();
-        } catch (e) {
-          err = e;
-        }
-
-        expect(err.message).toMatch(/Missing required parameters/);
-      });
-    });
-  });
   describe('deleteTagsSubscription', () => {
     describe('positive tests', () => {
       function __deleteTagsSubscriptionTest() {
@@ -2571,6 +2439,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('createSubscription', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.
@@ -2683,6 +2552,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('listSubscriptions', () => {
     describe('positive tests', () => {
       function __listSubscriptionsTest() {
@@ -2776,6 +2646,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('getSubscription', () => {
     describe('positive tests', () => {
       function __getSubscriptionTest() {
@@ -2869,6 +2740,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('deleteSubscription', () => {
     describe('positive tests', () => {
       function __deleteSubscriptionTest() {
@@ -2962,6 +2834,7 @@ describe('EventNotificationsV1', () => {
       });
     });
   });
+
   describe('updateSubscription', () => {
     describe('positive tests', () => {
       // Request models needed by this operation.


### PR DESCRIPTION
## PR summary
Includes changes of Device count API, API spec lint errors fix, modification for EN Doc and pre prod

**Fixes:** #4555, #4280, #4455

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Device Count API is not there.
list of Destination devices and Retrieves report of destination devices registered are present to be removed.
Tag subscription API are listing under Destination tag subscription.
Tags are unordered.
Lint errors.
## What is the new behavior?  
Remove get list of Destination devices and Retrieves report of destination devices registered.
Add new header Push Destination API’s - to list all the tags and device count under this.
New Device count API 
Reordering of tags from Push Destination API’s (create, update, delete and listing)
Lint errors fixes.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information

signed-off-by: Nitish Kulkarni <nitish.kulkarni3@ibm.com>