### PR TITLE
chore: smtp response DKIM attribute fix

### DIFF
--- a/event-notifications/v1.ts
+++ b/event-notifications/v1.ts
@@ -4210,8 +4210,8 @@ namespace EventNotificationsV1 {
 
   /** Payload describing a SMTP configuration. */
   export interface SMTPConfig {
-    /** The DKIM attributes. */
-    dkim?: DKIMAttributes;
+    /** The SMTP DKIM attributes. */
+    dkim?: SMTPDKIMAttributes;
     /** The en_authorization attributes. */
     en_authorization?: ENAuthAttributes;
     /** The SPF attributes. */
@@ -4266,6 +4266,16 @@ namespace EventNotificationsV1 {
     config: SMTPConfig;
     /** Created time. */
     created_at: string;
+  }
+
+  /** The SMTP DKIM attributes. */
+  export interface SMTPDKIMAttributes {
+    /** DMIM text name. */
+    txt_name?: string;
+    /** DMIM text value. */
+    txt_value?: string;
+    /** DKIM verification. */
+    verification?: string;
   }
 
   /** Payload describing a SMTP User. */

--- a/test/integration/event-notifications.v1.test.js
+++ b/test/integration/event-notifications.v1.test.js
@@ -3022,6 +3022,9 @@ describe('EventNotificationsV1_integration', () => {
     expect(res.result.domain).toBeDefined();
     expect(res.result.name).toBeDefined();
     expect(res.result.description).toBeDefined();
+    expect(res.result.config.dkim).toBeDefined();
+    expect(res.result.config.spf).toBeDefined();
+    expect(res.result.config.en_authorization).toBeDefined();
   });
 
   test('getSMTPAllowedIPs()', async () => {

--- a/test/unit/event-notifications.v1.test.js
+++ b/test/unit/event-notifications.v1.test.js
@@ -22,6 +22,8 @@ const { NoAuthAuthenticator, unitTestUtils } = sdkCorePackage;
 const nock = require('nock');
 const EventNotificationsV1 = require('../../dist/event-notifications/v1');
 
+/* eslint-disable no-await-in-loop */
+
 const { getOptions, checkUrlAndMethod, checkMediaHeaders, expectToBePromise } = unitTestUtils;
 
 const eventNotificationsServiceOptions = {
@@ -4455,9 +4457,9 @@ describe('EventNotificationsV1', () => {
       const serviceUrl = eventNotificationsServiceOptions.url;
       const path = '/v1/instances/testString/smtp/config';
       const mockPagerResponse1 =
-        '{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"smtp_configurations":[{"id":"id","name":"name","description":"description","domain":"domain","config":{"dkim":{"public_key":"public_key","selector":"selector","verification":"verification"},"en_authorization":{"verification":"verification"},"spf":{"txt_name":"txt_name","txt_value":"txt_value","verification":"verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}';
+        '{"next":{"href":"https://myhost.com/somePath?offset=1"},"total_count":2,"limit":1,"smtp_configurations":[{"id":"id","name":"name","description":"description","domain":"domain","config":{"dkim":{"txt_name":"txt_name","txt_value":"txt_value","verification":"verification"},"en_authorization":{"verification":"verification"},"spf":{"txt_name":"txt_name","txt_value":"txt_value","verification":"verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}';
       const mockPagerResponse2 =
-        '{"total_count":2,"limit":1,"smtp_configurations":[{"id":"id","name":"name","description":"description","domain":"domain","config":{"dkim":{"public_key":"public_key","selector":"selector","verification":"verification"},"en_authorization":{"verification":"verification"},"spf":{"txt_name":"txt_name","txt_value":"txt_value","verification":"verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}';
+        '{"total_count":2,"limit":1,"smtp_configurations":[{"id":"id","name":"name","description":"description","domain":"domain","config":{"dkim":{"txt_name":"txt_name","txt_value":"txt_value","verification":"verification"},"en_authorization":{"verification":"verification"},"spf":{"txt_name":"txt_name","txt_value":"txt_value","verification":"verification"}},"updated_at":"2019-01-01T12:00:00.000Z"}]}';
 
       beforeEach(() => {
         unmock_createRequest();


### PR DESCRIPTION
## PR summary
SMTP configuration get and list response DKIM attributes txt_name and txt_value were not coming.

**Fixes:** https://github.ibm.com/Notification-Hub/planning/issues/13951

## PR Checklist
Please make sure that your PR fulfills the following requirements:
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?
SMTP configuration get and list response DKIM attributes txt_name and txt_value are not coming.

## What is the new behavior?
SMTP configuration get and list response has DKIM attributes with txt_name and txt_value.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
